### PR TITLE
Small clang fixes

### DIFF
--- a/include/async/algorithm.hpp
+++ b/include/async/algorithm.hpp
@@ -660,7 +660,7 @@ public:
 	bool start_inline() {
 		int n_fast = 0;
 		[&]<size_t... Is> (std::index_sequence<Is...>) {
-			([&] <size_t I> {
+			([&] <size_t I> () {
 				if(execution::start_inline(ops_.template get<I>()))
 					++n_fast;
 			}.template operator()<Is>(), ...);

--- a/include/async/cancellation.hpp
+++ b/include/async/cancellation.hpp
@@ -9,7 +9,7 @@ struct abstract_cancellation_callback {
 	friend struct cancellation_event;
 
 protected:
-	~abstract_cancellation_callback() = default;
+	virtual ~abstract_cancellation_callback() = default;
 
 private:
 	virtual void call() = 0;

--- a/include/async/queue.hpp
+++ b/include/async/queue.hpp
@@ -18,7 +18,7 @@ private:
 		friend struct queue;
 
 	protected:
-		~sink() = default;
+		virtual ~sink() = default;
 
 	public:
 		virtual void consume(T object) = 0;

--- a/include/async/result.hpp
+++ b/include/async/result.hpp
@@ -163,20 +163,20 @@ namespace detail {
 
 		auto initial_suspend() { return corons::suspend_always{}; }
 
-		auto final_suspend() {
+		auto final_suspend() noexcept {
 			struct awaiter {
 				awaiter(result_promise *p)
 				: _p{p} { }
 
-				bool await_ready() {
+				bool await_ready() noexcept {
 					return false;
 				}
 
-				void await_suspend(corons::coroutine_handle<>) {
+				void await_suspend(corons::coroutine_handle<>) noexcept {
 					_p->set_ready();
 				}
 
-				void await_resume() {
+				void await_resume() noexcept {
 					platform::panic("libasync: Internal fatal error:"
 							" Coroutine resumed from final suspension point");
 				}
@@ -224,20 +224,20 @@ namespace detail {
 
 		auto initial_suspend() { return corons::suspend_always{}; }
 
-		auto final_suspend() {
+		auto final_suspend() noexcept {
 			struct awaiter {
 				awaiter(result_promise *p)
 				: _p{p} { }
 
-				bool await_ready() {
+				bool await_ready() noexcept {
 					return false;
 				}
 
-				void await_suspend(corons::coroutine_handle<>) {
+				void await_suspend(corons::coroutine_handle<>) noexcept {
 					_p->set_ready();
 				}
 
-				void await_resume() {
+				void await_resume() noexcept {
 					platform::panic("libasync: Internal fatal error:"
 							" Coroutine resumed from final suspension point");
 				}


### PR DESCRIPTION
Clang 11 complains about several functions not being marked with `noexcept`. This PR fixes those issues, thus allowing libasync to be used with clang 11.