### PR TITLE
execution: Add missing include

### DIFF
--- a/include/async/execution.hpp
+++ b/include/async/execution.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
 
 namespace async {
 


### PR DESCRIPTION
This fixes an issue with compilation in freestanding environments with gcc versions >= 10