### PR TITLE
mutex: Fix several bugs in shared_mutex

### DIFF
--- a/include/async/mutex.hpp
+++ b/include/async/mutex.hpp
@@ -309,7 +309,6 @@ namespace detail {
 				}else{
 					assert(!shared_cnt_);
 					st_ = state::shared;
-					shared_cnt_ = 1;
 					while(waiters_.front()->desired == state::shared) {
 						pending.push_back(waiters_.pop_front());
 						++shared_cnt_;

--- a/include/async/mutex.hpp
+++ b/include/async/mutex.hpp
@@ -309,7 +309,7 @@ namespace detail {
 				}else{
 					assert(!shared_cnt_);
 					st_ = state::shared;
-					while(waiters_.front()->desired == state::shared) {
+					while(!waiters_.empty() && waiters_.front()->desired == state::shared) {
 						pending.push_back(waiters_.pop_front());
 						++shared_cnt_;
 					}


### PR DESCRIPTION
While debugging chromium, we came across two bugs in libasync, causing a system crash (missing !waiters_.empty() check) and a system hang (shared_cnt_ being initialized to 1). Please do check this very carefully to see if it is correct, tho I did not notice regressions.