### PR TITLE
queue: implement empty()

### DIFF
--- a/include/async/queue.hpp
+++ b/include/async/queue.hpp
@@ -140,6 +140,10 @@ public:
 		return {this, ct};
 	}
 
+	bool empty() {
+		return buffer_.empty();
+	}
+
 	frg::optional<T> maybe_get() {
 		frg::unique_lock lock{mutex_};
 


### PR DESCRIPTION
This is useful for implementing functions like `pollStatus` in managarm.