### PR TITLE
recurring-event: change to tristate return to reflect possible results

### DIFF
--- a/docs/src/headers/recurring-event.md
+++ b/docs/src/headers/recurring-event.md
@@ -30,15 +30,15 @@ if it's true, waits for the event to be raised.
 
 ### Arguments
 
- - `ct` - the cancellation token to use to listen for cancellation.
+- `ct` - the cancellation token to use to listen for cancellation.
 
 ### Return values
 
 1. This method doesn't return any value.
-2. This method returns a sender of unspecified type. The sender completes with either
-`true` to indicate success, or `false` to indicate that the wait was cancelled, or that
-the condition was false.
-3. Same as (2)
+2. This method returns a sender of unspecified type. The value_type is of type `wait_if_result`,
+which is `success` to indicate success, or `cancelled` to indicate that the wait was cancelled,
+or `conditionFailed` when the condition was false.
+3. This method returns `true` on success and `false` on cancellation.
 
 ## Examples
 
@@ -60,6 +60,7 @@ coro(3, ev);
 ```
 
 Possible output:
+
 ```
 1: Before wait
 2: Before wait

--- a/include/async/algorithm.hpp
+++ b/include/async/algorithm.hpp
@@ -838,7 +838,7 @@ template <typename Fn>
 struct [[nodiscard]] lambda_callable {
 	template <typename ...Args>
 	auto operator()(Args &&...args) {
-		return lambda_sender{
+		return lambda_sender<Fn, Args...>{
 			std::move(fn),
 			std::forward_as_tuple(std::forward<Args>(args)...)
 		};

--- a/include/async/basic.hpp
+++ b/include/async/basic.hpp
@@ -54,6 +54,16 @@ concept co_awaits_to = requires (Awaitable &&a) {
 	{ make_awaiter(std::forward<Awaitable>(a)).await_resume() } -> std::same_as<T>;
 };
 
+enum class maybe_cancelled {
+    not_cancelled,
+    cancelled,
+};
+
+enum class maybe_awaited {
+    awaited,
+    condition_failed,
+};
+
 // ----------------------------------------------------------------------------
 // sender_awaiter template.
 // ----------------------------------------------------------------------------

--- a/include/async/sequenced-event.hpp
+++ b/include/async/sequenced-event.hpp
@@ -23,7 +23,7 @@ struct sequenced_event {
 			auto seq = seq_.load(std::memory_order_acquire);
 			assert(seq >= in_seq);
 			return in_seq >= seq;
-		}, ct), [this] (bool) {
+		}, ct), [this] (auto) {
 			return seq_.load(std::memory_order_acquire);
 		});
 	}


### PR DESCRIPTION
A `wait_if` operation can have three results: `success` when the operation succeeds, `conditionFailed` when the condition predicate fails, or `cancelled` when the cancellation token signals cancellation. Previously, the folding into a `bool` result lost the distinction between the two non-success states.

Depends on managarm/managarm#961.